### PR TITLE
local caching 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,23 @@ julia:
   - 1.0
   - 1
   - nightly
-# env:
-#   - JULIA_NUM_THREADS=1
-#   - JULIA_NUM_THREADS=4
+env:
+  - JULIA_NUM_THREADS=1
+  - JULIA_NUM_THREADS=4
 
 notifications:
   email: false
 
+# only test threading for julia=1
 matrix:
  allow_failures:
  - julia: nightly
+ exclude:
+ - julia: "1.0"
+   env: "JULIA_NUM_THREADS=4" 
+ - julia: "nightly"
+   env: "JULIA_NUM_THREADS=4" 
+
 
 codecov: true
 coveralls: true

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "1.1.0"
 HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 RationalRoots = "308eb6b3-cc68-5ff3-9e97-c3c4da4fa681"
+ThreadSafeDicts = "4239201d-c60e-5e0a-9702-85d713665ba7"
 
 [compat]
 HalfIntegers = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -4,20 +4,21 @@ authors = ["Jutho Haegeman"]
 version = "1.1.0"
 
 [deps]
-RationalRoots = "308eb6b3-cc68-5ff3-9e97-c3c4da4fa681"
 HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
+RationalRoots = "308eb6b3-cc68-5ff3-9e97-c3c4da4fa681"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
-RationalRoots = "0.1"
 HalfIntegers = "1.0"
 Primes = "0.4"
+RationalRoots = "0.1"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "LinearAlgebra", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "1.1.0"
 HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 RationalRoots = "308eb6b3-cc68-5ff3-9e97-c3c4da4fa681"
-TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
 HalfIntegers = "1.0"

--- a/benchmark/bounded_benchmark.jl
+++ b/benchmark/bounded_benchmark.jl
@@ -3,7 +3,7 @@ using ThreadSafeDicts
 
 function test_serial(n::Int)
     new_cache = WignerCache()  # create a new cache
-    sum = 0.0
+    sum = zero(BigFloat)
     for i in 1:n
         for j in 1:n
             for k in 1:n
@@ -16,11 +16,11 @@ end
 
 function test_bounded(n::Int)
     WignerSymbols.__init__()
-    sum = 0.0
+    sum = zero(BigFloat)
     for i in 1:n
         for j in 1:n
             for k in 1:n
-                sum += wigner3j(Float64, i, j, k, 0, 0)
+                sum += wigner3j(BigFloat, i, j, k, 0, 0)
             end
         end
     end
@@ -30,12 +30,12 @@ end
 
 function test_threaded(n::Int)
     WignerSymbols.__init__()
-    summands = zeros(Float64, Threads.nthreads())
+    summands = zeros(BigFloat, Threads.nthreads())
     Threads.@threads for i in 1:n
         tid = Threads.threadid()
         for j in 1:n
             for k in 1:n
-                summands[tid] += wigner3j(Float64, i, j, k, 0, 0)
+                summands[tid] += wigner3j(BigFloat, i, j, k, 0, 0)
             end
         end
     end
@@ -43,13 +43,13 @@ function test_threaded(n::Int)
 end
 
 function test_threaded_specialized(n::Int)
-    caches = WignerSymbols.get_thread_caches(Float64, n)
-    summands = zeros(Float64, Threads.nthreads())
+    caches = WignerSymbols.get_thread_caches(BigFloat, n)
+    summands = zeros(BigFloat, Threads.nthreads())
     Threads.@threads for i in 1:n
         tid = Threads.threadid()
         for j in 1:n
             for k in 1:n
-                summands[tid] += wigner3j(caches[tid], Float64, i, j, k, 0, 0)
+                summands[tid] += wigner3j(caches[tid], BigFloat, i, j, k, 0, 0)
             end
         end
     end
@@ -58,23 +58,24 @@ end
 
 maxj = 150
 ##
-@time println("default serial:  ", test_serial(maxj))
-GC.gc()
-##
-@time println("bounded serial:  ", test_bounded(maxj))
-GC.gc()
-##
-@time println("bounded thread:  ", test_threaded(maxj))
-GC.gc()
-##
-@time println("bounded thread specialized:  ", test_threaded_specialized(maxj))
-GC.gc()
-##
 
-# caches, mydict = setup_caches(maxj)
-# GC.enable(false)
-# @time println("thread no GC:    ", test_threaded(maxj, caches, mydict))
-# GC.enable(true)
-# GC.gc()
-
+@time begin
+    println("default serial:  ", test_serial(maxj))
+    GC.gc()
+end
+##
+@time begin
+    println("bounded serial:  ", test_bounded(maxj))
+    GC.gc()
+end
+##
+@time begin
+    println("bounded thread:  ", test_threaded(maxj))
+    GC.gc()
+end
+##
+@time begin
+    println("specialized th:  ", test_threaded_specialized(maxj))
+    GC.gc()
+end
 ##

--- a/benchmark/bounded_benchmark.jl
+++ b/benchmark/bounded_benchmark.jl
@@ -57,25 +57,29 @@ function test_threaded_specialized(n::Int)
 end
 
 maxj = 150
-##
+
+## serial benchmarks
 
 @time begin
     println("default serial:  ", test_serial(maxj))
     GC.gc()
 end
-##
+
 @time begin
     println("bounded serial:  ", test_bounded(maxj))
     GC.gc()
 end
-##
+
+## threaded benchmarks
+
 @time begin
     println("bounded thread:  ", test_threaded(maxj))
     GC.gc()
 end
-##
+
 @time begin
     println("specialized th:  ", test_threaded_specialized(maxj))
     GC.gc()
 end
+
 ##

--- a/benchmark/bounded_benchmark.jl
+++ b/benchmark/bounded_benchmark.jl
@@ -3,35 +3,65 @@ using WignerSymbols
 function test_serial(n::Int)
     new_cache = WignerCache()  # create a new cache
     sum = 0.0
-    for i in 1000:n
-        sum = sum + wigner3j(new_cache, BigFloat, 5000, i, 5000, 0, 0)
+    for i in 1:n
+        for j in 1:n
+            for k in 1:n
+                sum += wigner3j(new_cache, BigFloat, i, j, k, 0, 0)
+            end
+        end
     end
     sum
 end
-
-using TimerOutputs
-WignerSymbols.__init__()
-reset_timer!(WignerSymbols.to)
-println(test_serial(1500))
-print(WignerSymbols.to)
-
-##  NEW =======
-GC.gc()
-using WignerSymbols
 
 function test_bounded(n::Int)
-    new_cache = BoundedWignerCache(5000)  # create a new cache
+    new_cache = BoundedWignerCache(n)  # create a new cache
     sum = 0.0
-    for i in 1000:n
-        sum = sum + wigner3j(new_cache, BigFloat, 5000, i, 5000, 0, 0)
+    for i in 1:n
+        for j in 1:n
+            for k in 1:n
+                sum += wigner3j(new_cache, BigFloat, i, j, k, 0, 0)
+            end
+        end
     end
     sum
 end
 
-using TimerOutputs
-WignerSymbols.__init__()
-reset_timer!(WignerSymbols.to)
-println(test_bounded(1500))
-print(WignerSymbols.to)
+function setup_caches(jmax)
+    caches = BoundedWignerCache[]
+    resize!(empty!(caches), Threads.nthreads())
+    for i in 1:Threads.nthreads()
+        cache = BoundedWignerCache(jmax)
+        caches[i] = cache
+    end
+    return caches
+end
 
+function test_threaded(n::Int, caches)
+    summands = zeros(BigFloat, Threads.nthreads())
+    Threads.@threads for i in 1:n
+        for j in 1:n
+            for k in 1:n
+                threadid = Threads.threadid()
+                summands[threadid] += wigner3j(caches[threadid], BigFloat, i, j, k, 0, 0)
+            end
+        end
+    end
+    sum(summands)
+end
+
+maxj = 120
+@time println("standard       ", test_serial(maxj))
+GC.gc()
+@time println("bounded cache: ", test_bounded(maxj))
+GC.gc()
+
+caches = setup_caches(maxj)
+@time println("threaded:      ", test_threaded(maxj, caches))
+GC.gc()
+
+caches = setup_caches(maxj)
+GC.enable(false)
+@time println("thread no GC:  ", test_threaded(maxj, caches))
+GC.enable(true)
+GC.gc()
 ##

--- a/benchmark/bounded_benchmark.jl
+++ b/benchmark/bounded_benchmark.jl
@@ -50,18 +50,19 @@ function test_threaded(n::Int, caches)
 end
 
 maxj = 120
-@time println("standard       ", test_serial(maxj))
+@time println("default serial:  ", test_serial(maxj))
 GC.gc()
-@time println("bounded cache: ", test_bounded(maxj))
+@time println("bounded serial:  ", test_bounded(maxj))
 GC.gc()
 
 caches = setup_caches(maxj)
-@time println("threaded:      ", test_threaded(maxj, caches))
+@time println("bounded thread:  ", test_threaded(maxj, caches))
 GC.gc()
 
 caches = setup_caches(maxj)
 GC.enable(false)
-@time println("thread no GC:  ", test_threaded(maxj, caches))
+@time println("thread no GC:    ", test_threaded(maxj, caches))
 GC.enable(true)
 GC.gc()
+
 ##

--- a/benchmark/bounded_benchmark.jl
+++ b/benchmark/bounded_benchmark.jl
@@ -1,4 +1,5 @@
 using WignerSymbols
+using ThreadSafeDicts
 
 function test_serial(n::Int)
     new_cache = WignerCache()  # create a new cache
@@ -14,55 +15,66 @@ function test_serial(n::Int)
 end
 
 function test_bounded(n::Int)
-    new_cache = BoundedWignerCache(n)  # create a new cache
+    WignerSymbols.__init__()
     sum = 0.0
     for i in 1:n
         for j in 1:n
             for k in 1:n
-                sum += wigner3j(new_cache, BigFloat, i, j, k, 0, 0)
+                sum += wigner3j(Float64, i, j, k, 0, 0)
             end
         end
     end
     sum
 end
 
-function setup_caches(jmax)
-    caches = BoundedWignerCache[]
-    resize!(empty!(caches), Threads.nthreads())
-    for i in 1:Threads.nthreads()
-        cache = BoundedWignerCache(jmax)
-        caches[i] = cache
-    end
-    return caches
-end
 
-function test_threaded(n::Int, caches)
-    summands = zeros(BigFloat, Threads.nthreads())
+function test_threaded(n::Int)
+    WignerSymbols.__init__()
+    summands = zeros(Float64, Threads.nthreads())
     Threads.@threads for i in 1:n
+        tid = Threads.threadid()
         for j in 1:n
             for k in 1:n
-                threadid = Threads.threadid()
-                summands[threadid] += wigner3j(caches[threadid], BigFloat, i, j, k, 0, 0)
+                summands[tid] += wigner3j(Float64, i, j, k, 0, 0)
             end
         end
     end
     sum(summands)
 end
 
-maxj = 120
+function test_threaded_specialized(n::Int)
+    caches = WignerSymbols.get_thread_caches(Float64, n)
+    summands = zeros(Float64, Threads.nthreads())
+    Threads.@threads for i in 1:n
+        tid = Threads.threadid()
+        for j in 1:n
+            for k in 1:n
+                summands[tid] += wigner3j(caches[tid], Float64, i, j, k, 0, 0)
+            end
+        end
+    end
+    sum(summands)
+end
+
+maxj = 150
+##
 @time println("default serial:  ", test_serial(maxj))
 GC.gc()
+##
 @time println("bounded serial:  ", test_bounded(maxj))
 GC.gc()
-
-caches = setup_caches(maxj)
-@time println("bounded thread:  ", test_threaded(maxj, caches))
+##
+@time println("bounded thread:  ", test_threaded(maxj))
 GC.gc()
-
-caches = setup_caches(maxj)
-GC.enable(false)
-@time println("thread no GC:    ", test_threaded(maxj, caches))
-GC.enable(true)
+##
+@time println("bounded thread specialized:  ", test_threaded_specialized(maxj))
 GC.gc()
+##
+
+# caches, mydict = setup_caches(maxj)
+# GC.enable(false)
+# @time println("thread no GC:    ", test_threaded(maxj, caches, mydict))
+# GC.enable(true)
+# GC.gc()
 
 ##

--- a/benchmark/bounded_benchmark.jl
+++ b/benchmark/bounded_benchmark.jl
@@ -1,0 +1,37 @@
+using WignerSymbols
+
+function test_serial(n::Int)
+    new_cache = WignerCache()  # create a new cache
+    sum = 0.0
+    for i in 1000:n
+        sum = sum + wigner3j(new_cache, BigFloat, 5000, i, 5000, 0, 0)
+    end
+    sum
+end
+
+using TimerOutputs
+WignerSymbols.__init__()
+reset_timer!(WignerSymbols.to)
+println(test_serial(1500))
+print(WignerSymbols.to)
+
+##  NEW =======
+GC.gc()
+using WignerSymbols
+
+function test_bounded(n::Int)
+    new_cache = BoundedWignerCache(5000)  # create a new cache
+    sum = 0.0
+    for i in 1000:n
+        sum = sum + wigner3j(new_cache, BigFloat, 5000, i, 5000, 0, 0)
+    end
+    sum
+end
+
+using TimerOutputs
+WignerSymbols.__init__()
+reset_timer!(WignerSymbols.to)
+println(test_bounded(1500))
+print(WignerSymbols.to)
+
+##

--- a/src/WignerSymbols.jl
+++ b/src/WignerSymbols.jl
@@ -52,7 +52,7 @@ function Δ(cache::WignerCache, T::Type{<:Real}, j₁, j₂, j₃)
     n, d = Δ²(cache, j₁, j₂, j₃)
     return convert(T, 
         signedroot(RationalRoot{BigInt}, 
-            convert(cache, BigInt, n)//convert(cache, BigInt, d)))
+            _convert(cache, BigInt, n)//_convert(cache, BigInt, d)))
 end
 
 """
@@ -106,8 +106,8 @@ function wigner3j(cache::WignerCache, T::Type{<:Real}, j₁, j₂, j₃, m₁, m
 
         snum, rnum = splitsquare(s1n*s2n)
         sden, rden = splitsquare(s1d)
-        s = convert(cache, BigInt, snum) // convert(cache, BigInt, sden)
-        r = convert(cache, BigInt, rnum) // convert(cache, BigInt, rden)
+        s = _convert(cache, BigInt, snum) // _convert(cache, BigInt, sden)
+        r = _convert(cache, BigInt, rnum) // _convert(cache, BigInt, rden)
         s *= compute3jseries(cache, β₁, β₂, β₃, α₁, α₂)
         cache.Wigner3j[(β₁, β₂, β₃, α₁, α₂)] = (r,s)
     end
@@ -211,8 +211,8 @@ function wigner6j(cache::WignerCache, T::Type{<:Real}, j₁, j₂, j₃, j₄, j
         sden, rden = splitsquare(d₁ * d₂ * d₃ * d₄)
         snu, sden = divgcd!(snum, sden)
         rnu, rden = divgcd!(rnum, rden)
-        s = convert(cache, BigInt, snum) // convert(cache, BigInt, sden)
-        r = convert(cache, BigInt, rnum) // convert(cache, BigInt, rden)
+        s = _convert(cache, BigInt, snum) // _convert(cache, BigInt, sden)
+        r = _convert(cache, BigInt, rnum) // _convert(cache, BigInt, rden)
         s *= compute6jseries(cache, β₁, β₂, β₃, α₁, α₂, α₃, α₄)
 
         cache.Wigner6j[(β₁, β₂, β₃, α₁, α₂, α₃)] = (r, s)
@@ -311,7 +311,7 @@ function compute3jseries(cache::WignerCache, β₁, β₂, β₃, α₁, α₂)
     end
     den = commondenominator!(nums, dens)
     totalnum = sumlist!(cache, nums)
-    totalden = convert(cache, BigInt, den)
+    totalden = _convert(cache, BigInt, den)
     return totalnum//totalden
 end
 
@@ -331,7 +331,7 @@ function compute6jseries(cache::WignerCache, β₁, β₂, β₃, α₁, α₂, 
     end
     den = commondenominator!(nums, dens)
     totalnum = sumlist!(cache, nums)
-    totalden = convert(cache, BigInt, den)
+    totalden = _convert(cache, BigInt, den)
     return totalnum//totalden
 end
 

--- a/src/WignerSymbols.jl
+++ b/src/WignerSymbols.jl
@@ -9,6 +9,13 @@ const RRBig = RationalRoot{BigInt}
 import RationalRoots: _convert
 
 include("wignercache.jl")
+function __init__()
+    global default_cache
+    # rehash global dictionaries for precompile
+    Base.rehash!(default_cache.Wigner3j)
+    Base.rehash!(default_cache.Wigner6j)
+end
+
 include("primefactorization.jl")
 
 # check integerness and correctness of (j,m) angular momentum

--- a/src/WignerSymbols.jl
+++ b/src/WignerSymbols.jl
@@ -7,7 +7,7 @@ using HalfIntegers
 using RationalRoots
 const RRBig = RationalRoot{BigInt}
 import RationalRoots: _convert
-
+using ThreadSafeDicts
 include("wignercache.jl")
 include("primefactorization.jl")
 include("boundedcache.jl")
@@ -25,6 +25,9 @@ const wigner_caches = WignerCache[]
     end
     return cache
 end
+
+const Wigner3j = ThreadSafeDict{Tuple{UInt,UInt,UInt,Int,Int},Tuple{Rational{BigInt},Rational{BigInt}}}()
+const Wigner6j = ThreadSafeDict{NTuple{6,UInt},Tuple{Rational{BigInt},Rational{BigInt}}}()
 
 function __init__()
     global wigner_caches

--- a/src/WignerSymbols.jl
+++ b/src/WignerSymbols.jl
@@ -8,10 +8,6 @@ using RationalRoots
 const RRBig = RationalRoot{BigInt}
 import RationalRoots: _convert
 
-# debug stuff
-using TimerOutputs
-const to = TimerOutput()
-
 include("wignercache.jl")
 include("primefactorization.jl")
 include("boundedcache.jl")
@@ -319,16 +315,16 @@ function compute3jseries(cache::WignerCache, β₁, β₂, β₃, α₁, α₂)
 
     nums = Vector{T}(undef, length(krange))
     dens = Vector{T}(undef, length(krange))
-    @timeit to "3jseries k loop" for (i, k) in enumerate(krange)
+    for (i, k) in enumerate(krange)
         num = iseven(k) ? one(T) : -one(T)
         den = primefactorial(cache, k)*primefactorial(cache, k-α₁)*
             primefactorial(cache, k-α₂)*primefactorial(cache, β₁-k)*
             primefactorial(cache, β₂-k)*primefactorial(cache, β₃-k)
         nums[i], dens[i] = divgcd!(num, den)
     end
-    @timeit to "commondenominator!" den = commondenominator!(nums, dens)
-    @timeit to "totalnum" totalnum = sumlist!(cache, nums)
-    @timeit to "totalden" totalden = _convert(cache, BigInt, den)
+    den = commondenominator!(nums, dens)
+    totalnum = sumlist!(cache, nums)
+    totalden = _convert(cache, BigInt, den)
     return totalnum//totalden
 end
 

--- a/src/WignerSymbols.jl
+++ b/src/WignerSymbols.jl
@@ -122,6 +122,7 @@ function wigner3j(cache::WignerCache, T::Type{<:Real}, j₁, j₂, j₃, m₁, m
 
         snum, rnum = splitsquare(s1n*s2n)
         sden, rden = splitsquare(s1d)
+
         s = _convert(cache, BigInt, snum) // _convert(cache, BigInt, sden)
         r = _convert(cache, BigInt, rnum) // _convert(cache, BigInt, rden)
         s *= compute3jseries(cache, β₁, β₂, β₃, α₁, α₂)

--- a/src/WignerSymbols.jl
+++ b/src/WignerSymbols.jl
@@ -1,6 +1,6 @@
 __precompile__(true)
 module WignerSymbols
-export δ, Δ, clebschgordan, wigner3j, wigner6j, racahV, racahW, HalfInteger
+export δ, Δ, clebschgordan, wigner3j, wigner6j, racahV, racahW, HalfInteger, WignerCache
 
 using Base.GMP.MPZ
 using HalfIntegers

--- a/src/WignerSymbols.jl
+++ b/src/WignerSymbols.jl
@@ -187,7 +187,7 @@ the `jᵢ`s are not integer or halfinteger.
 """
 wigner6j(j₁, j₂, j₃, j₄, j₅, j₆) = wigner6j(get_local_cache(), RRBig, j₁, j₂, j₃, j₄, j₅, j₆)
 wigner6j(T::Type{<:Real}, j₁, j₂, j₃, j₄, j₅, j₆) = wigner6j(get_local_cache(), T, j₁, j₂, j₃, j₄, j₅, j₆)
-wigner6j(cache::WignerCache, j₁, j₂, j₃, j₄, j₅, j₆) = wigner6j(cache, RRBig, j₁, j₂, j₃, j₄, j₅, j₆)
+wigner6j(cache::AbstractWignerCache, j₁, j₂, j₃, j₄, j₅, j₆) = wigner6j(cache, RRBig, j₁, j₂, j₃, j₄, j₅, j₆)
 function wigner6j(cache::WignerCache, T::Type{<:Real}, j₁, j₂, j₃, j₄, j₅, j₆)
     # check validity of `jᵢ`s
     for jᵢ in (j₁, j₂, j₃, j₄, j₅, j₆)
@@ -252,9 +252,9 @@ the `jᵢ`s and `J`s are not integer or halfinteger.
 """
 racahW(j₁, j₂, J, j₃, J₁₂, J₂₃) = racahW(
     get_local_cache(), RRBig, j₁, j₂, J, j₃, J₁₂, J₂₃)
-racahW(cache::WignerCache, j₁, j₂, J, j₃, J₁₂, J₂₃) = racahW(
+racahW(cache::AbstractWignerCache, j₁, j₂, J, j₃, J₁₂, J₂₃) = racahW(
     cache, RRBig, j₁, j₂, J, j₃, J₁₂, J₂₃)
-function racahW(cache::WignerCache, T::Type{<:Real}, j₁, j₂, J, j₃, J₁₂, J₂₃)
+function racahW(cache::AbstractWignerCache, T::Type{<:Real}, j₁, j₂, J, j₃, J₁₂, J₂₃)
     s = wigner6j(cache, T, j₁, j₂, J₁₂, j₃, J, J₂₃)
     if !iszero(s) && isodd(convert(Int, j₁ + j₂ + j₃ + J))
         return -s

--- a/src/boundedcache.jl
+++ b/src/boundedcache.jl
@@ -1,0 +1,324 @@
+
+
+isnonzero(x::T) where {T<:Integer} = (x != zero(T))
+function get_last_nonzero(vec::Vector{T}) where T
+    last_nonzero_index = findlast(isnonzero, vec)
+    if (isnothing(last_nonzero_index))
+        return 1
+    end
+    return last_nonzero_index
+end
+
+# A custom `Integer` subtype to store an integer as its prime factorization
+mutable struct StaticPrimeFactorization{U<:Unsigned} <: AbstractPrimeFactorization{U}
+    powers::Vector{U}
+    sign::Int8
+    last_nonzero_index::Int
+end
+StaticPrimeFactorization(powers::Vector{U}) where {U<:Unsigned} =
+    StaticPrimeFactorization{U}(powers, one(Int8), get_last_nonzero(powers))
+StaticPrimeFactorization(powers::Vector{U}, sign::Integer) where {U<:Unsigned} =
+    StaticPrimeFactorization{U}(powers, sign > 0 ? one(Int8) : -one(Int8), 
+        get_last_nonzero(powers))
+
+
+struct BoundedWignerCache <: AbstractWignerCache
+    Wigner3j::Dict{Tuple{UInt,UInt,UInt,Int,Int},Tuple{Rational{BigInt},Rational{BigInt}}}
+    Wigner6j::Dict{NTuple{6,UInt},Tuple{Rational{BigInt},Rational{BigInt}}}
+
+    primetable::Array{Int64,1}
+    factortable::Array{Array{UInt8,1},1}
+    factorialtable::Array{Array{UInt32,1},1}
+    bigprimetable::Array{Array{BigInt,1},1}
+    bigone::Base.RefValue{BigInt}
+
+    # numerators and denominator buffers in order to GCD the sums
+    nums::Array{StaticPrimeFactorization{UInt32},1}
+    dens::Array{StaticPrimeFactorization{UInt32},1}
+
+    # prime factorization buffers
+    numbuf::StaticPrimeFactorization{UInt32}
+    denbuf::StaticPrimeFactorization{UInt32}
+end
+
+
+"""
+Bounds based on Table 3 of Johansson and Forssén 2016.
+
+Set nj=3 for 3j, nj=6 for 6j, nj=9 for 9j.
+"""
+function BoundedWignerCache(max_j::T; nj=3) where {T <: Integer}
+    multiplier = Int(2 + round(nj / 3))
+    maxfactorial = multiplier * max_j + 1
+    maxt = max_j + 1
+
+    cache = BoundedWignerCache(
+        Dict{Tuple{UInt,UInt,UInt,Int,Int},Tuple{Rational{BigInt},Rational{BigInt}}}(),
+        Dict{NTuple{6,UInt},Tuple{Rational{BigInt},Rational{BigInt}}}(),
+        [2,3,5],
+        [UInt8[], UInt8[1], UInt8[0,1], UInt8[2], UInt8[0,0,1]],
+        [UInt32[], UInt32[], UInt32[1], UInt32[1,1], UInt32[3,1], UInt32[3,1,1]],
+        [[big(2)], [big(3)], [big(5)]],
+        Ref{BigInt}(big(1)),
+        [StaticPrimeFactorization(zeros(UInt32, maxfactorial), one(Int8),1) for i in 1:maxt],
+        [StaticPrimeFactorization(zeros(UInt32, maxfactorial), one(Int8),1) for i in 1:maxt],
+        StaticPrimeFactorization(zeros(UInt32, maxfactorial), one(Int8),1),
+        StaticPrimeFactorization(zeros(UInt32, maxfactorial), one(Int8),1)
+    )
+    return cache
+end
+
+function precompute_primefactorial!(cache::BoundedWignerCache, n::Integer)
+    n < 0 && throw(DomainError(n))
+    m = length(cache.factorialtable)-1
+    @inbounds while m < n
+        prevfactorial = cache.factorialtable[m+1]
+        m += 1
+        f = primefactor(cache, m).powers
+        powers = copy(prevfactorial)
+        if length(f) > length(powers) # can at most be 1 larger
+            push!(powers, 0)
+        end
+        for k = 1:length(f)
+            powers[k] += f[k]
+        end
+        push!(cache.factorialtable, powers)
+    end
+end
+
+
+"""
+Perform an in-place multiplication of a prime factorization of a factorial.
+"""
+function mul_primefactorial!(cache::BoundedWignerCache, 
+        fact_dest::AbstractPrimeFactorization{T}, n::Integer) where T
+    precompute_primefactorial!(cache, n)
+    row = cache.factorialtable[n+1]
+    for i in 1:length(row)
+        fact_dest.powers[i] += row[i]
+    end
+    fact_dest.last_nonzero_index = max(length(row), fact_dest.last_nonzero_index)
+    return
+end
+
+function one!(fact_dest::AbstractPrimeFactorization{T}, sign::Integer) where T
+    for i in 1:fact_dest.last_nonzero_index
+        fact_dest.powers[i] = zero(T)
+    end
+    # fill!(fact_dest.powers, zero(T))
+    fact_dest.sign = sign < 0 ? -one(Int8) : one(Int8)
+    fact_dest.last_nonzero_index = 1
+    return
+end
+
+# function divgcd!(cache::BoundedWignerCache, 
+#         a::AbstractPrimeFactorization, b::AbstractPrimeFactorization)
+#     af, bf = a.powers, b.powers
+#     last_nonzero_a = findfirst(iszero, af) - 1
+#     last_nonzero_b = findfirst(iszero, bf) - 1
+
+#     for k = 1:min(last_nonzero_a, last_nonzero_b)
+#         gk = min(af[k], bf[k])
+#         af[k] -= gk
+#         bf[k] -= gk
+#     end
+#     return
+# end
+
+function _vmin!(a::StaticPrimeFactorization{U}, 
+    b::StaticPrimeFactorization{U}) where {U<:Unsigned}
+    af = a.powers
+    bf = b.powers
+    @inbounds for k = 1:a.last_nonzero_index
+        af[k] = min(af[k], bf[k])
+    end
+    return 
+end
+
+function _vsub!(a::StaticPrimeFactorization{U}, 
+    b::StaticPrimeFactorization{U}) where {U<:Unsigned}
+    af = a.powers
+    bf = b.powers
+    @inbounds for k = 1:b.last_nonzero_index
+        af[k] -= bf[k]
+    end
+    a.last_nonzero_index = max(a.last_nonzero_index, b.last_nonzero_index)
+end
+
+function _vadd!(a::StaticPrimeFactorization{U}, 
+    b::StaticPrimeFactorization{U}) where {U<:Unsigned}
+    af = a.powers
+    bf = b.powers
+    @inbounds for k = 1:b.last_nonzero_index
+        af[k] = +(af[k], bf[k])
+    end
+    a.last_nonzero_index = max(a.last_nonzero_index, b.last_nonzero_index)
+end
+
+
+
+"""
+Given a list of numerators and denominators, compute the common denominator and
+the rescaled numerator after putting all fractions at the same common denominator.
+
+This deposits the common denominator in the `cache.denbuf`.
+"""
+function commondenominator!(cache::BoundedWignerCache, nums::Vector{P}, 
+        dens::Vector{P}, nk::Integer) where {P<:AbstractPrimeFactorization}
+
+    isempty(nums) && return one(P)
+    iszero(nk) && return one(P)
+    # accumulate lcm of denominator
+
+    den = cache.denbuf
+    den.powers .= dens[1].powers
+    den.last_nonzero_index = dens[1].last_nonzero_index
+
+    for i = 2:nk
+        den.powers .= max.(den.powers, dens[i].powers)
+        den.last_nonzero_index = max(den.last_nonzero_index, dens[i].last_nonzero_index)
+    end
+
+    # rescale numerators
+    for i = 1:nk
+        _vadd!(nums[i], den)
+        _vsub!(nums[i], dens[i])
+    end
+    return
+end
+
+function _convert(cache::BoundedWignerCache, T::Type{BigInt}, a::StaticPrimeFactorization)
+    A = one(BigInt)
+    # for (n, e) in enumerate(a.powers)
+    for n in 1:a.last_nonzero_index
+        e = a.powers[n]
+        if !iszero(e)
+            MPZ.mul!(A, bigprime(cache, n, e))
+        end
+    end
+    return a.sign < 0 ? MPZ.neg!(A) : A
+end
+
+# auxiliary function to compute sums of a list of PrimeFactorizations as quickly as possible
+function sumlist!(cache::BoundedWignerCache, list::Vector{P}, 
+        ind = 1:length(list)) where {P <: StaticPrimeFactorization}
+    # first compute gcd to take out common factors
+    g = StaticPrimeFactorization(
+        copy(list[ind[1]].powers[1:list[ind[1]].last_nonzero_index]), one(Int8), 
+        list[ind[1]].last_nonzero_index)
+    for k in ind
+        _vmin!(g, list[k])
+    end
+    for k in ind
+        _vsub!(list[k], g)
+    end
+    L = length(ind)
+    if L > 32
+        l = L >> 1
+        s = sumlist!(cache, list, first(ind).+(0:l-1)) + sumlist!(
+                cache, list, first(ind).+(l:L-1))
+    else
+        # do sum
+        s = big(0)
+        for k in ind
+            MPZ.add!(s, _convert(cache, BigInt, list[k]))
+        end
+    end
+    return MPZ.mul!(s, _convert(cache, BigInt, g))
+end
+
+
+# squared triangle coefficient
+function Δ²(cache::BoundedWignerCache, j₁, j₂, j₃)
+    # also checks the triangle conditions by converting to unsigned integer:
+    num = cache.numbuf
+    one!(num, 1)
+    mul_primefactorial!(cache, num, convert(UInt, + j₁ + j₂ - j₃) )
+    mul_primefactorial!(cache, num, convert(UInt, + j₁ - j₂ + j₃) )
+    mul_primefactorial!(cache, num, convert(UInt, - j₁ + j₂ + j₃) )
+
+    den = cache.denbuf
+    one!(den, 1)
+    mul_primefactorial!(cache, den, convert(UInt, j₁ + j₂ + j₃ + 1) )
+    # result
+    return num, den
+end
+
+# compute the sum appearing in the 3j symbol
+function compute3jseries(cache::BoundedWignerCache, β₁, β₂, β₃, α₁, α₂)
+    krange = max(α₁, α₂, zero(α₁)):min(β₁, β₂, β₃)
+    numk = length(krange)
+    T_int = eltype(eltype(cache.factorialtable))
+    T = PrimeFactorization{T_int}
+
+    nums = cache.nums
+    dens = cache.dens
+    @timeit to "3jseries k loop" for (i, k) in enumerate(krange)
+        num = nums[i]
+        den = dens[i]
+        one!(num, iseven(k) ? 1 : -1)
+        one!(den, 1)
+
+        mul_primefactorial!(cache, den, k)
+        mul_primefactorial!(cache, den, k-α₁)
+        mul_primefactorial!(cache, den, k-α₂)
+        mul_primefactorial!(cache, den, β₁-k)
+        mul_primefactorial!(cache, den, β₂-k)
+        mul_primefactorial!(cache, den, β₃-k)
+
+        # divgcd!(cache, num, den)
+    end
+
+     # write gcd to buffer
+    @timeit to "commondenominator!" commondenominator!(cache, nums, dens, numk) 
+    @timeit to "totalden" totalden = _convert(cache, BigInt, cache.denbuf)
+    @timeit to "totalnum" totalnum = sumlist!(cache, nums[1:numk])
+    return totalnum//totalden
+end
+
+
+wigner3j(cache::BoundedWignerCache, j₁, j₂, j₃, m₁, m₂, m₃ = -m₁-m₂) = wigner3j(
+    cache, RRBig, j₁, j₂, j₃, m₁, m₂, m₃)
+function wigner3j(cache::BoundedWignerCache, T::Type{<:Real}, j₁, j₂, j₃, m₁, m₂, m₃ = -m₁-m₂)
+    # check angular momenta
+    for (jᵢ,mᵢ) in ((j₁, m₁), (j₂, m₂), (j₃, m₃))
+        ϵ(jᵢ, mᵢ) || throw(DomainError((jᵢ, mᵢ), "invalid combination (jᵢ, mᵢ)"))
+    end
+    # check triangle condition and m₁+m₂+m₃ == 0
+    if !δ(j₁, j₂, j₃) || !iszero(m₁+m₂+m₃)
+        return zero(T)
+    end
+
+    # we reorder such that j₁ >= j₂ >= j₃ and m₁ >= 0 or m₁ == 0 && m₂ >= 0
+    j₁, j₂, j₃, m₁, m₂, m₃, sgn = reorder3j(j₁, j₂, j₃, m₁, m₂, m₃)
+    # TODO: do we also want to use Regge symmetries?
+    α₁ = convert(Int, j₂ - m₁ - j₃ ) # can be negative
+    α₂ = convert(Int, j₁ + m₂ - j₃ ) # can be negative
+    β₁ = convert(Int, j₁ + j₂ - j₃ )
+    β₂ = convert(Int, j₁ - m₁ )
+    β₃ = convert(Int, j₂ + m₂ )
+
+    # extra sign in definition: α₁ - α₂ = j₁ + m₂ - j₂ + m₁ = j₁ - j₂ + m₃
+    sgn = isodd(α₁ - α₂) ? -sgn : sgn
+
+    # dictionary lookup or compute
+    if haskey(cache.Wigner3j, (β₁, β₂, β₃, α₁, α₂))
+        r, s = cache.Wigner3j[(β₁, β₂, β₃, α₁, α₂)]
+    else
+
+        s1n, s1d = Δ²(cache, j₁, j₂, j₃)
+        s2n = (
+            primefactorial(cache, β₂) * primefactorial(cache, β₁ - α₁) * primefactorial(cache, β₁ - α₂) *
+            primefactorial(cache, β₃) * primefactorial(cache, β₃ - α₁) * primefactorial(cache, β₂ - α₂))
+
+        snum, rnum = splitsquare(s1n*s2n)
+        sden, rden = splitsquare(s1d)
+
+        s = _convert(cache, BigInt, snum) // _convert(cache, BigInt, sden)
+        r = _convert(cache, BigInt, rnum) // _convert(cache, BigInt, rden)
+
+        s *= compute3jseries(cache, β₁, β₂, β₃, α₁, α₂)
+        cache.Wigner3j[(β₁, β₂, β₃, α₁, α₂)] = (r,s)
+    end
+    return convert(T, sgn*s)*convert(T, signedroot(r))
+end

--- a/src/boundedcache.jl
+++ b/src/boundedcache.jl
@@ -128,12 +128,6 @@ function BoundedWignerCache(
     maxt = max_j + 1
     max_prime_factors = πbound(maxfactorial)
 
-    addbuffer = BigInt(;nbits=bound_factorial(maxfactorial))
-    seriesnum = BigInt(;nbits=bound_factorial(maxfactorial))
-    seriesden = BigInt(;nbits=bound_factorial(maxfactorial))
-
-    Base.GMP.MPZ.set!(addbuffer, big(0))
-
     cache = BoundedWignerCache{Tdict}(
         multiplier,
         Ref{Int}(max_j),
@@ -149,14 +143,14 @@ function BoundedWignerCache(
         factorbuffer(max_prime_factors),  # numbuf
         factorbuffer(max_prime_factors),  # denbuf
 
-        Ref{BigInt}(addbuffer),
-        Ref{BigInt}(seriesnum),
-        Ref{BigInt}(seriesden),
+        Ref{BigInt}(big(0)),
+        Ref{BigInt}(big(0)),
+        Ref{BigInt}(big(0)),
         
-        Ref{BigInt}(BigInt(;nbits=bound_factorial(maxfactorial))),
-        Ref{BigInt}(BigInt(;nbits=bound_factorial(maxfactorial))),
-        Ref{BigInt}(BigInt(;nbits=bound_factorial(maxfactorial))),
-        Ref{BigInt}(BigInt(;nbits=bound_factorial(maxfactorial))),
+        Ref{BigInt}(big(0)),
+        Ref{BigInt}(big(0)),
+        Ref{BigInt}(big(0)),
+        Ref{BigInt}(big(0)),
 
         factorbuffer(max_prime_factors),  # s2n
         factorbuffer(max_prime_factors),  # snum 

--- a/src/boundedcache.jl
+++ b/src/boundedcache.jl
@@ -24,7 +24,7 @@ function wigner_dicts(Tdict::Type{<:Real})
 end
 
 function get_thread_caches(Tdict::Type{<:Real}, maxj::Integer)
-    d3, d6 = WignerSymbols.wigner_dicts(Float64)
+    d3, d6 = WignerSymbols.wigner_dicts(Tdict)
     caches = BoundedWignerCache[]
     resize!(empty!(caches), Threads.nthreads())
     Threads.@threads for i in 1:Threads.nthreads()

--- a/src/boundedcache.jl
+++ b/src/boundedcache.jl
@@ -231,6 +231,7 @@ function commondenominator!(cache::BoundedWignerCache, nums::Vector{P},
 end
 
 function _convert!(cache::BoundedWignerCache, A::BigInt, a::StaticPrimeFactorization)
+    MPZ.set!(A, cache.bigone[])
     @inbounds for n in 1:a.last_nonzero_index
         e = a.powers[n]
         if !iszero(e)
@@ -275,10 +276,9 @@ function sumlist!(cache::BoundedWignerCache, list::Vector{P},
     else
         # do sum
         s = big(0)
-        summand = big(1)
+        # summand = big(1)
         for k in ind
-            MPZ.set!(summand, cache.bigone[])
-            MPZ.add!(s, _convert!(cache, summand, list[k]))
+            MPZ.add!(s, _convert!(cache, cache.addbuf[], list[k]))
         end
     end
     return MPZ.mul!(s, gint)
@@ -369,8 +369,8 @@ function wigner3j(cache::BoundedWignerCache, T::Type{<:Real}, j₁, j₂, j₃, 
     sgn = isodd(α₁ - α₂) ? -sgn : sgn
 
     # dictionary lookup or compute
-    if haskey(cache.Wigner3j, (β₁, β₂, β₃, α₁, α₂))
-        r, s = cache.Wigner3j[(β₁, β₂, β₃, α₁, α₂)]
+    if haskey(Wigner3j, (β₁, β₂, β₃, α₁, α₂))
+        r, s = Wigner3j[(β₁, β₂, β₃, α₁, α₂)]
     else
         s1n, s1d = cache.numbuf, cache.denbuf
         s2n, snum, rnum, sden, rden = cache.s2n, cache.snum, cache.rnum, cache.sden, cache.rden
@@ -388,7 +388,7 @@ function wigner3j(cache::BoundedWignerCache, T::Type{<:Real}, j₁, j₂, j₃, 
         r = _convert(cache, BigInt, rnum) // _convert(cache, BigInt, rden)
 
         s *= compute3jseries(cache, β₁, β₂, β₃, α₁, α₂)
-        cache.Wigner3j[(β₁, β₂, β₃, α₁, α₂)] = (r,s)
+        Wigner3j[(β₁, β₂, β₃, α₁, α₂)] = (r,s)
     end
     return convert(T, sgn*s)*convert(T, signedroot(r))
 end

--- a/src/primefactorization.jl
+++ b/src/primefactorization.jl
@@ -35,7 +35,7 @@ function bigprime(cache::WignerCache, n::Integer, e::Integer=1)
     @inbounds while l < e
         # compute next prime power as approximate square of existing results
         k = (l+1)>>1
-        push!(cache.bigprimetable[n], 
+        push!(cache.bigprimetable[n],
               cache.bigprimetable[n][k] * cache.bigprimetable[n][l+1-k])
         l += 1
     end
@@ -106,7 +106,7 @@ Base.zero(::Type{PrimeFactorization{U}}) where {U<:Unsigned} =
 Base.promote_rule(P::Type{<:PrimeFactorization},::Type{<:Integer}) = P
 Base.promote_rule(P::Type{<:PrimeFactorization},::Type{BigInt}) = BigInt
 
-_convert(cache::WignerCache, P::Type{<:PrimeFactorization}, 
+_convert(cache::WignerCache, P::Type{<:PrimeFactorization},
     n::Integer) = _convert(P, primefactor(cache, n))
 function _convert(cache::WignerCache, T::Type{BigInt}, a::PrimeFactorization)
     A = one(BigInt)

--- a/src/primefactorization.jl
+++ b/src/primefactorization.jl
@@ -106,9 +106,9 @@ Base.zero(::Type{PrimeFactorization{U}}) where {U<:Unsigned} =
 Base.promote_rule(P::Type{<:PrimeFactorization},::Type{<:Integer}) = P
 Base.promote_rule(P::Type{<:PrimeFactorization},::Type{BigInt}) = BigInt
 
-Base.convert(cache::WignerCache, P::Type{<:PrimeFactorization}, 
-    n::Integer) = convert(P, primefactor(cache, n))
-function Base.convert(cache::WignerCache, T::Type{BigInt}, a::PrimeFactorization)
+_convert(cache::WignerCache, P::Type{<:PrimeFactorization}, 
+    n::Integer) = _convert(P, primefactor(cache, n))
+function _convert(cache::WignerCache, T::Type{BigInt}, a::PrimeFactorization)
     A = one(BigInt)
     for (n, e) in enumerate(a.powers)
         if !iszero(e)
@@ -237,10 +237,10 @@ function sumlist!(cache::WignerCache, list::Vector{<:PrimeFactorization}, ind = 
         # do sum
         s = big(0)
         for k in ind
-            MPZ.add!(s, convert(cache, BigInt, list[k]))
+            MPZ.add!(s, _convert(cache, BigInt, list[k]))
         end
     end
-    return MPZ.mul!(s, convert(cache, BigInt, g))
+    return MPZ.mul!(s, _convert(cache, BigInt, g))
 end
 
 # Mutating vector methods that also grow and shrink as required

--- a/src/wignercache.jl
+++ b/src/wignercache.jl
@@ -25,9 +25,6 @@ function WignerCache()
     cache.bigprimetable[1][1] = big(2)
     cache.bigprimetable[2][1] = big(3)
     cache.bigprimetable[3][1] = big(5)
-    Base.rehash!(cache.Wigner3j)
-    Base.rehash!(cache.Wigner6j)
-
     return cache
 end
 

--- a/src/wignercache.jl
+++ b/src/wignercache.jl
@@ -22,9 +22,5 @@ function WignerCache()
         [[big(2)], [big(3)], [big(5)]],
         Ref{BigInt}(big(1))
     )
-    cache.bigone[] = big(1)
-    cache.bigprimetable[1][1] = big(2)
-    cache.bigprimetable[2][1] = big(3)
-    cache.bigprimetable[3][1] = big(5)
     return cache
 end

--- a/src/wignercache.jl
+++ b/src/wignercache.jl
@@ -1,0 +1,35 @@
+
+
+struct WignerCache
+    Wigner3j::Dict{Tuple{UInt,UInt,UInt,Int,Int},Tuple{Rational{BigInt},Rational{BigInt}}}
+    Wigner6j::Dict{NTuple{6,UInt},Tuple{Rational{BigInt},Rational{BigInt}}}
+
+    primetable::Array{Int64,1}
+    factortable::Array{Array{UInt8,1},1}
+    factorialtable::Array{Array{UInt32,1},1}
+    bigprimetable::Array{Array{BigInt,1},1}
+    bigone::Base.RefValue{BigInt}
+end
+
+function WignerCache()
+    cache = WignerCache(
+        Dict{Tuple{UInt,UInt,UInt,Int,Int},Tuple{Rational{BigInt},Rational{BigInt}}}(),
+        Dict{NTuple{6,UInt},Tuple{Rational{BigInt},Rational{BigInt}}}(),
+        [2,3,5],
+        [UInt8[], UInt8[1], UInt8[0,1], UInt8[2], UInt8[0,0,1]],
+        [UInt32[], UInt32[], UInt32[1], UInt32[1,1], UInt32[3,1], UInt32[3,1,1]],
+        [[big(2)], [big(3)], [big(5)]],
+        Ref{BigInt}(big(1))
+    )
+    cache.bigone[] = big(1)
+    cache.bigprimetable[1][1] = big(2)
+    cache.bigprimetable[2][1] = big(3)
+    cache.bigprimetable[3][1] = big(5)
+    Base.rehash!(cache.Wigner3j)
+    Base.rehash!(cache.Wigner6j)
+
+    return cache
+end
+
+default_cache = WignerCache()
+

--- a/src/wignercache.jl
+++ b/src/wignercache.jl
@@ -1,6 +1,7 @@
 
+abstract type AbstractWignerCache end
 
-struct WignerCache
+struct WignerCache <: AbstractWignerCache
     Wigner3j::Dict{Tuple{UInt,UInt,UInt,Int,Int},Tuple{Rational{BigInt},Rational{BigInt}}}
     Wigner6j::Dict{NTuple{6,UInt},Tuple{Rational{BigInt},Rational{BigInt}}}
 
@@ -27,6 +28,3 @@ function WignerCache()
     cache.bigprimetable[3][1] = big(5)
     return cache
 end
-
-default_cache = WignerCache()
-

--- a/test/boundedtests.jl
+++ b/test/boundedtests.jl
@@ -1,0 +1,51 @@
+using Test
+using WignerSymbols
+using LinearAlgebra
+using Random
+
+Random.seed!(1234)
+smalljlist = 0:1//2:10
+largejlist = 0:1//2:1000
+
+cache = BoundedWignerCache(1000)
+
+# test recurrence relations: Phys Rev E 57, 7274 (1998)
+@testset "bounded wigner3j: test recurrence relations" begin
+    for k = 1:10
+        j2 = convert(BigFloat, rand(0:1//2:1000))
+        j3 = convert(BigFloat, rand(0:1//2:1000))
+        m2 = convert(BigFloat, rand(-j2:j2))
+        m3 = convert(BigFloat, rand(-j3:j3))
+
+        for j in max(abs(j2-j3),abs(m2+m3))+1:(j2+j3)-1
+            X = j*sqrt(((j+1)^2-(j2-j3)^2)*((j2+j3+1)^2-(j+1)^2)*((j+1)^2-(m2+m3)^2))
+            Y = (2*j+1)*((m2+m3)*(j2*(j2+1)-j3*(j3+1)) - (m2-m3)*j*(j+1))
+            Z = (j+1)*sqrt((j^2-(j2-j3)^2)*((j2+j3+1)^2-j^2)*(j^2-(m2+m3)^2))
+            tol = 10*max(abs(X),abs(Y),abs(Z))*eps(BigFloat)
+            @test (X*wigner3j(cache, BigFloat,j+1,j2,j3,-m2-m3,m2,m3) +
+                        Z*wigner3j(cache, BigFloat,j-1,j2,j3,-m2-m3,m2,m3)) ≈
+                            (-Y*wigner3j(cache, BigFloat,j,j2,j3,-m2-m3,m2,m3)) atol=tol
+        end
+    end
+end
+
+@testset "bounded wigner3j: test orthogonality relations" begin
+    # equivalent to Clebsch-Gordan orthogonality, now test using Float32
+    for j1 in smalljlist, j2 in smalljlist
+        d1::Int = 2*j1+1
+        d2::Int = 2*j2+1
+        M = zeros(Float32, (d1*d2, d1*d2))
+        ind2 = 1
+        for m1 in -j1:j1, m2 in -j2:j2
+            ind1 = 1
+            @inbounds for j3 in abs(j1-j2):(j1+j2), m3 in -j3:j3
+                d3::Int = 2*j3+1
+                M[ind1,ind2] += sqrt(d3) * wigner3j(cache, Float32, j1, j2, j3, m1, m2, m3)
+                ind1 += 1
+            end
+            ind2 += 1
+        end
+        @test M'*M ≈ one(M) # orthogonality relation type 1
+        @test M*M' ≈ one(M) # orthogonality relation type 2
+    end
+end

--- a/test/prev_tests.jl
+++ b/test/prev_tests.jl
@@ -10,7 +10,7 @@ largejlist = 0:1//2:1000
 cache = WignerCache()
 
 # test recurrence relations: Phys Rev E 57, 7274 (1998)
-@testset "bounded wigner3j: test recurrence relations" begin
+@testset "wigner3j: test recurrence relations" begin
     for k = 1:10
         j2 = convert(BigFloat, rand(0:1//2:1000))
         j3 = convert(BigFloat, rand(0:1//2:1000))
@@ -29,7 +29,7 @@ cache = WignerCache()
     end
 end
 
-@testset "bounded wigner3j: test orthogonality relations" begin
+@testset "wigner3j: test orthogonality relations" begin
     # equivalent to Clebsch-Gordan orthogonality, now test using Float32
     for j1 in smalljlist, j2 in smalljlist
         d1::Int = 2*j1+1

--- a/test/prev_tests.jl
+++ b/test/prev_tests.jl
@@ -7,7 +7,7 @@ Random.seed!(1234)
 smalljlist = 0:1//2:10
 largejlist = 0:1//2:1000
 
-cache = BoundedWignerCache(1000)
+cache = WignerCache()
 
 # test recurrence relations: Phys Rev E 57, 7274 (1998)
 @testset "bounded wigner3j: test recurrence relations" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,6 @@ Random.seed!(1234)
 smalljlist = 0:1//2:10
 largejlist = 0:1//2:1000
 
-# include("prevtests.jl")
-
 @testset "triangle coefficient" begin
     for j1 in smalljlist, j2 in smalljlist
         for j3 = abs(j1-j2):(j1+j2)
@@ -167,3 +165,6 @@ end
         end
     end
 end
+
+# compare threaded and old serial implementation
+include("threadtests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,8 @@ Random.seed!(1234)
 smalljlist = 0:1//2:10
 largejlist = 0:1//2:1000
 
+include("boundedtests.jl")
+
 @testset "triangle coefficient" begin
     for j1 in smalljlist, j2 in smalljlist
         for j3 = abs(j1-j2):(j1+j2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ Random.seed!(1234)
 smalljlist = 0:1//2:10
 largejlist = 0:1//2:1000
 
-include("boundedtests.jl")
+# include("prevtests.jl")
 
 @testset "triangle coefficient" begin
     for j1 in smalljlist, j2 in smalljlist
@@ -20,7 +20,7 @@ include("boundedtests.jl")
     end
 end
 
-# test 3j:
+## test 3j:
 #--------
 @testset "clebschgordan: test orthogonality" begin
     for j1 in smalljlist, j2 in smalljlist
@@ -40,7 +40,7 @@ end
     end
 end
 
-# test recurrence relations: Phys Rev E 57, 7274 (1998)
+## test recurrence relations: Phys Rev E 57, 7274 (1998)
 @testset "wigner3j: test recurrence relations" begin
     for k = 1:10
         j2 = convert(BigFloat, rand(0:1//2:1000))
@@ -81,7 +81,7 @@ end
     end
 end
 
-# test 6j
+## test 6j
 #----------
 @testset "wigner6j: test orthogonality" begin
     for j1 in smalljlist, j2 in smalljlist, j4 in smalljlist

--- a/test/threadtests.jl
+++ b/test/threadtests.jl
@@ -1,0 +1,62 @@
+using Test
+using WignerSymbols
+
+## wigner3j summation tests
+function test_serial_3j(n::Int)
+    new_cache = WignerCache()  # create a new cache
+    sum = zero(BigFloat)
+    for i in 1:n
+        for j in 1:n
+            for k in 1:n
+                sum += wigner3j(new_cache, BigFloat, i, j, k, 0, 0)
+            end
+        end
+    end
+    sum
+end
+
+function test_threaded_3j(n::Int)
+    WignerSymbols.__init__()  # reset global caches
+    summands = zeros(BigFloat, Threads.nthreads())
+    Threads.@threads for i in 1:n
+        tid = Threads.threadid()
+        for j in 1:n
+            for k in 1:n
+                summands[tid] += wigner3j(BigFloat, i, j, k, 0, 0)
+            end
+        end
+    end
+    sum(summands)
+end
+
+@testset "wigner3j threaded sum" begin
+    for max_j in [7, 30, 100]
+        tol = 10*max_j*eps(BigFloat)
+        @test test_serial_3j(max_j) ≈ test_threaded_3j(max_j) atol=tol
+    end
+end
+
+## wigner6j summation tests
+function test_serial_6j(n::Int)
+    new_cache = WignerCache()  # create a new cache
+    s = zero(BigFloat)
+    for i in 1:n
+        s += wigner6j(new_cache, BigFloat, i, i, i, i, i, i)
+    end
+    s
+end
+
+function test_threaded_6j(n::Int)
+    summands = zeros(BigFloat, Threads.nthreads())
+    Threads.@threads for i in 1:n
+        summands[Threads.threadid()] += wigner6j(BigFloat, i, i, i, i, i, i)
+    end
+    sum(summands)
+end
+
+@testset "wigner6j threaded sum" begin
+    for max_j in [7, 51, 100, 300, 701]
+        tol = 10*max_j*eps(BigFloat)
+        @test test_serial_6j(max_j) ≈ test_threaded_6j(max_j) atol=tol
+    end
+end


### PR DESCRIPTION
This attempts to resolve #12 by adding `struct WignerCache` and passing such objects around. This allows for thread-local caches, like in the example below.

The code itself is probably uglier at first glance, because every function which used caches now has signature `some_func(cache::WignerCache, ...)`. I think it might be easier to develop though, since one no longer has to touch a global state. To keep the API stable, there is a global `default_cache` which preserves the current default behavior when one doesn't pass a `WignerCache`. The current tests and benchmarks shouldn't need any modification.

Looking forward to any comments.

```julia
using WignerSymbols
using BenchmarkTools

function test_serial()
    new_cache = WignerCache()  # create a new cache
    wigner3j(new_cache, BigFloat, 10000, 10000, 1000, 200, -300); 
end

# this test is on an old 16 core workstation
function test_threads()
    sum = zero(BigFloat)
    # create a cache for each thread
    caches = [WignerCache() for th in 1:Threads.nthreads()]
    @sync Threads.@threads for i in 1:16  # compute 16 of the same thing
        sum += wigner3j(caches[Threads.threadid()], BigFloat, 
            10000, 10000, 1000, 200, -300)
    end
    sum
end

## 
@btime test_serial();
## 818.303 ms (560055 allocations: 334.97 MiB)
@btime test_threads();
## 1.109 s (8961031 allocations: 5.23 GiB)
```