### PR TITLE
add `wigner9j` symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Manifest.toml
 *.jl.cov
 *.jl.*.cov
 *.jl.mem

--- a/Project.toml
+++ b/Project.toml
@@ -1,25 +1,26 @@
 name = "WignerSymbols"
 uuid = "9f57e263-0b3d-5e2e-b1be-24f2bb48858b"
 authors = ["Jutho Haegeman"]
-version = "2.0.0"
+version = "2.1.0"
 
 [deps]
-RationalRoots = "308eb6b3-cc68-5ff3-9e97-c3c4da4fa681"
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"
-Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
+Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
+RationalRoots = "308eb6b3-cc68-5ff3-9e97-c3c4da4fa681"
 
 [compat]
-RationalRoots = "0.1 - 0.9"
 HalfIntegers = "1"
-Primes = "0.4 - 0.9"
 LRUCache = "1.3"
+Primes = "0.4 - 0.9"
+RationalRoots = "0.1 - 0.9"
 julia = "1.5"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "LinearAlgebra", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Jutho Haegeman"]
 version = "2.1.0"
 
 [deps]
-Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 Primes = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Largely based on reading the paper (but not the code):
 with some additional modifications to further improve efficiency for large `j` (angular
 momenta quantum numbers).
 
-In particular, 3j and 6j symbols are computed exactly, in the format `√(r) * s` where `r`
+In particular, 3j, 6j, and 9j symbols are computed exactly, in the format `√(r) * s` where `r`
 and `s` are exactly computed as `Rational{BigInt}`, using an intermediate representation
 based on prime number factorization. This exact representation is captured by the
 `RationalRoot` type. For further calculations, these values probably need to be converted

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ While the following function signatures are probably self-explanatory, you can q
 for them in the Julia REPL to get further details.
 *   `wigner3j(T::Type{<:Real} = RationalRoot{BigInt}, j₁, j₂, j₃, m₁, m₂, m₃ = -m₂-m₁) -> ::T`
 *   `wigner6j(T::Type{<:Real} = RationalRoot{BigInt}, j₁, j₂, j₃, j₄, j₅, j₆) -> ::T`
+*   `wigner9j(T::Type{<:Real} = RationalRoot{BigInt}, j₁, j₂, j₃, j₄, j₅, j₆, j₇, j₈, j₉) -> ::T`
 *   `clebschgordan(T::Type{<:Real} = RationalRoot{BigInt}, j₁, m₁, j₂, m₂, j₃, m₃ = m₁+m₂) -> ::T`
 *   `racahV(T::Type{<:Real} = RationalRoot{BigInt}, j₁, j₂, j₃, m₁, m₂, m₃ = -m₁-m₂) -> ::T`
 *   `racahW(T::Type{<:Real} = RationalRoot{BigInt}, j₁, j₂, J, j₃, J₁₂, J₂₃) -> ::T`
@@ -89,9 +90,8 @@ Also uses ideas from
 
 [2] [J. Rasch and A. C. H. Yu, SIAM Journal on Scientific Compututing 25 (2003), 1416–1428](https://doi.org/10.1137/S1064827503422932)
 
-for caching the computed 3j and 6j symbols.
+for caching the computed 3j and 6j symbols. Wigner 9-j symbols implemented based on 
 
-## Todo
-*   Wigner 9-j symbols, as explained in [1] and based on
+[3] [L. Wei, New formula for 9-j symbols and their direct calculation, Computers in Physics, 12 (1998), 632–634.](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.481.5946&rep=rep1&type=pdf)
 
-    [3] [L. Wei, New formula for 9-j symbols and their direct calculation, Computers in Physics, 12 (1998), 632–634.](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.481.5946&rep=rep1&type=pdf)
+with binomials additionally optimized using the methods described in [1].

--- a/src/WignerSymbols.jl
+++ b/src/WignerSymbols.jl
@@ -285,8 +285,8 @@ function _wigner9j(T::Type{<:Real}, j₁::HalfInteger, j₂::HalfInteger, j₃::
     # dictionary lookup, check all 72 permutations 
     k = [j₁ j₂ j₃; j₄ j₅ j₆; j₇ j₈ j₉]
     for p in _perms9j
-        kk = tuple(reshape(k[p...], 9))
-        kkT = tuple(reshape(transpose(k[p...]), 9))
+        kk = Tuple(reshape(k[p...], 9))
+        kkT = Tuple(reshape(transpose(k[p...]), 9))
         if haskey(Wigner9j, kk)
             r, s = Wigner9j[kk]
             return _convert(T, s) * convert(T, signedroot(r))

--- a/src/WignerSymbols.jl
+++ b/src/WignerSymbols.jl
@@ -454,7 +454,7 @@ function compute9jseries(a, b, c, d, e, f, g, h, j)
     I2 = min(h + d, b + f, a + j)
     krange = I1:I2
  
-    sum(krange) do k
+    return sum(krange) do k
         p = iseven(2k) ? big(2k + 1) : -big(2k + 1)
 
         b₁ = let (m₁, m₂, m₃, m₄, m₅, m₆) = (a, b, c, f, j, k)     

--- a/src/WignerSymbols.jl
+++ b/src/WignerSymbols.jl
@@ -494,7 +494,6 @@ function compute9jseries(a, b, c, d, e, f, g, h, j)
     end
 end
 
-export wei9jbracket
 # Wei square bracket terms appearing the 9j series
 function wei9jbracket(α₁::BigInt, α₂::BigInt, α₃::BigInt, β₁::BigInt, β₂::BigInt, β₃::BigInt, β₀::BigInt) 
     p = max(β₁, β₂, β₃, β₀)

--- a/src/WignerSymbols.jl
+++ b/src/WignerSymbols.jl
@@ -6,7 +6,6 @@ using RationalRoots
 using LRUCache
 const RRBig = RationalRoot{BigInt}
 import RationalRoots: _convert
-using Combinatorics: permutations
 
 include("growinglist.jl")
 include("bigint.jl") # additional GMP BigInt functionality not wrapped in Base.GMP.MPZ
@@ -270,8 +269,19 @@ function wigner9j(T::Type{<:Real}, j₁, j₂, j₃, j₄, j₅, j₆, j₇, j�
     return _wigner9j(T, HalfInteger.((j₁, j₂, j₃, j₄, j₅, j₆, j₇, j₈, j₉))...)
 end
 
-const _perms9j = [(i, j) for i in permutations([1, 2, 3]), 
-                       j in permutations([1, 2, 3])]
+const _perms9j = [([1, 2, 3], [1, 2, 3]) ([1, 2, 3], [1, 3, 2]) ([1, 2, 3], [2, 1, 3]) ([1, 2, 3], [2, 3, 1]) ([1, 2, 3], [3, 1, 2]) ([1, 2, 3], [3, 2, 1]);
+                  ([1, 3, 2], [1, 2, 3]) ([1, 3, 2], [1, 3, 2]) ([1, 3, 2], [2, 1, 3]) ([1, 3, 2], [2, 3, 1]) ([1, 3, 2], [3, 1, 2]) ([1, 3, 2], [3, 2, 1]);
+                  ([2, 1, 3], [1, 2, 3]) ([2, 1, 3], [1, 3, 2]) ([2, 1, 3], [2, 1, 3]) ([2, 1, 3], [2, 3, 1]) ([2, 1, 3], [3, 1, 2]) ([2, 1, 3], [3, 2, 1]);
+                  ([2, 3, 1], [1, 2, 3]) ([2, 3, 1], [1, 3, 2]) ([2, 3, 1], [2, 1, 3]) ([2, 3, 1], [2, 3, 1]) ([2, 3, 1], [3, 1, 2]) ([2, 3, 1], [3, 2, 1]);
+                  ([3, 1, 2], [1, 2, 3]) ([3, 1, 2], [1, 3, 2]) ([3, 1, 2], [2, 1, 3]) ([3, 1, 2], [2, 3, 1]) ([3, 1, 2], [3, 1, 2]) ([3, 1, 2], [3, 2, 1]);
+                  ([3, 2, 1], [1, 2, 3]) ([3, 2, 1], [1, 3, 2]) ([3, 2, 1], [2, 1, 3]) ([3, 2, 1], [2, 3, 1]) ([3, 2, 1], [3, 1, 2]) ([3, 2, 1], [3, 2, 1])]
+
+const _signs9j = [1 -1 -1 1 1 -1;
+                  -1 1 1 -1 -1 1;
+                  -1 1 1 -1 -1 1;
+                  1 -1 -1 1 1 -1;
+                  1 -1 -1 1 1 -1;
+                  -1 1 1 -1 -1 1]
 
 function _wigner9j(T::Type{<:Real}, j₁::HalfInteger, j₂::HalfInteger, j₃::HalfInteger, 
                                     j₄::HalfInteger, j₅::HalfInteger, j₆::HalfInteger,
@@ -284,15 +294,15 @@ function _wigner9j(T::Type{<:Real}, j₁::HalfInteger, j₂::HalfInteger, j₃::
    
     # dictionary lookup, check all 72 permutations 
     k = [j₁ j₂ j₃; j₄ j₅ j₆; j₇ j₈ j₉]
-    for p in _perms9j
+    for (p, m) in zip(_perms9j, _signs9j)
         kk = Tuple(reshape(k[p...], 9))
         kkT = Tuple(reshape(transpose(k[p...]), 9))
         if haskey(Wigner9j, kk)
             r, s = Wigner9j[kk]
-            return _convert(T, s) * convert(T, signedroot(r))
+            return m * _convert(T, s) * convert(T, signedroot(r))
         elseif haskey(Wigner9j, kkT)
             r, s = Wigner9j[kkT]
-            return _convert(T, s) * convert(T, signedroot(r)) 
+            return m * _convert(T, s) * convert(T, signedroot(r)) 
         end
     end
 

--- a/src/primefactorization.jl
+++ b/src/primefactorization.jl
@@ -407,9 +407,7 @@ end
 
 function primebinomial(n::BigInt, k::BigInt)
     num = copy(primefactorial(n))
-    den = copy(primefactorial(k))
-    den = mul!(den, primefactorial(n - k))
-    res = divexact!(num, den)
-    return res
+    divexact!(num, primefactorial(k))
+    return divexact!(num, primefactorial(n-k))
 end
 

--- a/src/primefactorization.jl
+++ b/src/primefactorization.jl
@@ -384,3 +384,32 @@ function sumlist!(list::Vector{<:PrimeFactorization}, ind = 1:length(list))
     end
     return MPZ.mul!(s, _convert!(i, g))
 end
+
+#=
+# A cached binomial implementation.
+bcache = LRU{Tuple{BigInt, BigInt}, PrimeFactorization}(; maxsize=10^6)
+function primebinomial(n::BigInt, k::BigInt)
+    T = PrimeFactorization{eltype(eltype(factorialtable))}
+    if k == 0
+        return one(T)
+    end # guard
+    if haskey(bcache, (n, k))
+        return bcache[(n, k)]
+    else
+        den = primefactor(k)
+        num = mul!(copy(primefactor(n + 1 - k)), primebinomial(n, k - 1)) 
+        res = divexact!(num, den)
+        bcache[(n, k)] = res
+        return res
+    end
+end
+=#
+
+function primebinomial(n::BigInt, k::BigInt)
+    num = copy(primefactorial(n))
+    den = copy(primefactorial(k))
+    den = mul!(den, primefactorial(n - k))
+    res = divexact!(num, den)
+    return res
+end
+

--- a/src/primefactorization.jl
+++ b/src/primefactorization.jl
@@ -385,26 +385,6 @@ function sumlist!(list::Vector{<:PrimeFactorization}, ind = 1:length(list))
     return MPZ.mul!(s, _convert!(i, g))
 end
 
-#=
-# A cached binomial implementation.
-bcache = LRU{Tuple{BigInt, BigInt}, PrimeFactorization}(; maxsize=10^6)
-function primebinomial(n::BigInt, k::BigInt)
-    T = PrimeFactorization{eltype(eltype(factorialtable))}
-    if k == 0
-        return one(T)
-    end # guard
-    if haskey(bcache, (n, k))
-        return bcache[(n, k)]
-    else
-        den = primefactor(k)
-        num = mul!(copy(primefactor(n + 1 - k)), primebinomial(n, k - 1)) 
-        res = divexact!(num, den)
-        bcache[(n, k)] = res
-        return res
-    end
-end
-=#
-
 function primebinomial(n::BigInt, k::BigInt)
     num = copy(primefactorial(n))
     divexact!(num, primefactorial(k))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,3 +207,23 @@ end
         end
     end
 end
+
+@threads for i = 1:N
+    @testset "wigner9j: relation to sum over 6j products, thread $i" begin
+        for k = 1:10_000
+            @testset let (j1, j2, j3, j4, j5, j6, j7, j8, j9) = rand(smalljlist, 9)
+                @test wigner9j(j1, j2, j3, 
+                           j4, j5, j6, 
+                           j7, j8, j9) ≈ sum(largejlist) do x # lazy choice for range of this sum, but good enough
+                                            (iseven(2x) ? (2x + 1) : -(2x + 1)) *
+                                            wigner6j(j1, j4, j7,
+                                                     j8, j9, x ) *
+                                            wigner6j(j2, j5, j8,
+                                                     j4, x , j6) *
+                                            wigner6j(j3, j6, j9,
+                                                     x , j1, j2)
+                               end
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,7 +211,7 @@ end
 @threads for i = 1:N
     @testset "wigner9j: relation to sum over 6j products, thread $i" begin
         for k = 1:10_000
-            @testset let (j1, j2, j3, j4, j5, j6, j7, j8, j9) = rand(smalljlist, 9)
+            let (j1, j2, j3, j4, j5, j6, j7, j8, j9) = rand(smalljlist, 9)
                 @test wigner9j(j1, j2, j3, 
                            j4, j5, j6, 
                            j7, j8, j9) ≈ sum(largejlist) do x # lazy choice for range of this sum, but good enough


### PR DESCRIPTION
Hi!

I've taken a rough pass at minimally implementing the 9j symbols based on L. Wei (1998) with binomials optimized according to the methods in Johansson & Forssen (2015), per the README's TODO. I'm new to package-quality `Julia`, but tried to use mostly similar patterns to the older code - for readability and minimal impact on that existing code.

Based on a bit of profiling, the computation runs reasonably quickly, is exact, and tests well against the decomposition in terms of sums of products of 6j symbols. There's likely still some performance to be gained.

I'd be happy to take any feedback/make any edits! :) Sorry for any trouble due to inexperience packaging.